### PR TITLE
Update secure_ssp_driver.c

### DIFF
--- a/core/drivers/secure_ssp_driver.c
+++ b/core/drivers/secure_ssp_driver.c
@@ -49,7 +49,9 @@ union {
 	struct device *dev_array[2];
 } devices = { { NULL, NULL } };
 
-const char *write_prefix = "";
+#define WRITE_PREFIX 	"Normal World"
+#define OUT_BUFF_SIZE	500
+static char out_buff[OUT_BUFF_SIZE] = {0};
 
 static struct itr_handler console_itr = {
 	// .it = CFG_UART_BASE,
@@ -110,12 +112,11 @@ static TEE_Result write_chars(bool secure __unused, uint32_t ptypes,
 
 	char *buf = params[0].memref.buffer;
 	unsigned int size = params[0].memref.size;
-	char local[5 + 2 + size];
-	memcpy(local, write_prefix, 5);
-	memcpy(&local[5], ": ", 2);
-	memcpy(&local[7], buf, size);
 
-	IMSG("%s", local);
+	memset(out_buff, 0, OUT_BUFF_SIZE);
+	memcpy(out_buff, buf, size);
+
+	IMSG("%s: %s", WRITE_PREFIX, out_buff);
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Fix bug in write_chars when printing with empty write_prefix.
Change from local buffer with dynamic size to static buffer with fixed size

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
